### PR TITLE
Add instruction count to dwter::eval function

### DIFF
--- a/dwarfter/dwarfter.cpp
+++ b/dwarfter/dwarfter.cpp
@@ -316,10 +316,11 @@ std::uint64_t dwter::eval(const std::vector<std::byte>& memory, std::uint64_t ba
         stack.pop_back();
         stack.push_back(op(lhs, rhs) ? 1 : 0);
         };
-
+    std::uint64_t n = 0;
     while (!cur.finished()) {
         auto opcode = cur.fixed<std::uint8_t>();
 
+        n++;
         if (debug) {
             std::cout << "opcode: " << opcode_to_string(opcode) << std::endl;
             std::cout << "stack: " << std::endl;
@@ -522,5 +523,6 @@ std::uint64_t dwter::eval(const std::vector<std::byte>& memory, std::uint64_t ba
         case DW_OP_bit_piece: throw std::runtime_error("Unsupported opcode DW_OP_bit_piece");
         }
     }
+    std::cout << "Number of instructions:" << n << std::endl;
     return stack.back();
 }


### PR DESCRIPTION
#### PR Classification
This pull request introduces a new feature for tracking and displaying the number of instructions executed in a specific while loop.

#### PR Summary
A new variable `n` has been added to count the number of instructions executed in a while loop. After the loop, the count is printed to the console.
- Added a `std::uint64_t` variable `n` to count the instructions executed in the while loop.
- Incremented `n` for each iteration in the while loop.
- Printed the value of `n` to the console after the loop execution.
